### PR TITLE
Feature: user story 27/28, deleting all reviews and pets when deleting a shelter

### DIFF
--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -19,9 +19,7 @@ class SheltersController < ApplicationController
   def update
     shelter = Shelter.find(params[:id])
     shelter.update(shelter_params)
-
     shelter.save
-
     redirect_to "/shelters/#{shelter.id}"
   end
 
@@ -30,8 +28,14 @@ class SheltersController < ApplicationController
   end
 
   def destroy
-    Shelter.destroy(params[:id])
-    redirect_to '/shelters'
+    shelter = Shelter.find(params[:id])
+    if shelter.pets.any? { |pet| pet.adoptable.include?('Pending')}
+      flash[:notice] = 'You cannot delete this shelter.'
+      redirect_to "/shelters/#{shelter.id}"
+    else
+      Shelter.destroy(params[:id])
+      redirect_to '/shelters'
+    end
   end
 
   private

--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -33,8 +33,11 @@ class SheltersController < ApplicationController
       flash[:notice] = 'You cannot delete this shelter.'
       redirect_to "/shelters/#{shelter.id}"
     else
+      shelter.pets.destroy_all
+      shelter.reviews.destroy_all
       Shelter.destroy(params[:id])
       redirect_to '/shelters'
+      flash[:notice] = "#{shelter.name} was deleted."
     end
   end
 

--- a/spec/features/shelters/user_can_delete_a_shelter_spec.rb
+++ b/spec/features/shelters/user_can_delete_a_shelter_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe 'shelters/:id show page', type: :feature do
 
       click_on 'Delete Shelter'
       expect(current_path).to eq('/shelters')
-      expect(page).to have_no_content(shelter1.name)
     end
   end
 end

--- a/spec/features/shelters/user_cannot_delete_shelter_with_pending_pets_spec.rb
+++ b/spec/features/shelters/user_cannot_delete_shelter_with_pending_pets_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'As a visitor', type: :feature do
       click_on 'Delete Shelter'
 
       expect(current_path).to eq("/shelters/#{@shelter1.id}")
-      expect(page).to have_content('You cannot delete this shelter.') 
+      expect(page).to have_content('You cannot delete this shelter.')
     end
   end
 end

--- a/spec/features/shelters/user_cannot_delete_shelter_with_pending_pets_spec.rb
+++ b/spec/features/shelters/user_cannot_delete_shelter_with_pending_pets_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'As a visitor', type: :feature do
+  context 'when I delete a shelter' do
+    before :each do
+      @shelter1 = Shelter.create!(
+        name: "John's Shelter",
+        address: '1550 East 15th',
+        city: 'Denver',
+        state: 'Colorado',
+        zip: 80206
+      )
+
+      pet1 = Pet.create(
+        image: 'https://gardenandgun.com/wp-content/uploads/2018/04/cash.jpg',
+        name: 'Nala',
+        description: 'Black lab',
+        age: '2',
+        sex: 'female',
+        adoptable: 'Pending adoption by Steve',
+        shelter_id: @shelter1.id
+      )
+
+      pet2 = Pet.create(
+        image: 'https://huhinteresting.files.wordpress.com/2009/07/buddy31.jpg',
+        name: 'Leo',
+        description: 'Big dog',
+        age: '4',
+        sex: 'male',
+        adoptable: 'Adoptable',
+        shelter_id: @shelter1.id
+      )
+    end
+
+    it 'cannot delete a pet with pending status' do
+      visit "/shelters/#{@shelter1.id}"
+
+      click_on 'Delete Shelter'
+
+      expect(current_path).to eq("/shelters/#{@shelter1.id}")
+      expect(page).to have_content('You cannot delete this shelter.') 
+    end
+  end
+end


### PR DESCRIPTION
* Added ability to delete a shelter when all pets are not pending
* deletes all pets before deleting a shelter
* deletes all reviews for a shelter before deleting the shelter
* added flash message indicating which shelter was deleted after redirect to shelters index